### PR TITLE
feat(eav, graphql): cache customAttributeMetadata

### DIFF
--- a/Model/CacheIdentity.php
+++ b/Model/CacheIdentity.php
@@ -2,12 +2,64 @@
 
 namespace Graycore\CustomAttributeMetadataCache\Model;
 
+use Magento\Catalog\Model\Product as ProductEntityType;
+use Magento\Eav\Api\Data\AttributeInterface;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Eav\Model\Entity\Attribute;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory as AttributeCollectionFactory;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Query\Resolver\IdentityInterface;
 
 class CacheIdentity implements IdentityInterface
 {
+    private AttributeCollectionFactory $attributeCollectionFactory;
+    private EavConfig $eavConfig;
+
+    public function __construct(AttributeCollectionFactory $attributeCollectionFactory, EavConfig $eavConfig)
+    {
+        $this->attributeCollectionFactory = $attributeCollectionFactory;
+        $this->eavConfig = $eavConfig;
+    }
+
+    private function mapAttributesByEntityType(array $resolvedData): array
+    {
+        $data = [];
+        foreach ($resolvedData['items'] ?? [] as $item) {
+            $data[$item['entity_type']][] = $item;
+        }
+        return $data;
+    }
+
+    private function getEavAttributeIds(string $entityTypeId, array $attributeCodes): array
+    {
+        return array_map(
+            fn(AttributeInterface $attribute) => Attribute::CACHE_TAG . '_' . $attribute->getAttributeId(),
+            $this->attributeCollectionFactory->create()
+                ->addFieldToFilter(
+                    AttributeInterface::ENTITY_TYPE_ID,
+                    ['eq' => $entityTypeId]
+                )
+                ->addFieldToFilter(
+                    AttributeInterface::ATTRIBUTE_CODE,
+                    ['in' => $attributeCodes]
+                )->getItems()
+        );
+    }
+
     public function getIdentities(array $resolvedData): array
     {
-        return [];
+        $identities = [];
+        foreach ($this->mapAttributesByEntityType($resolvedData) as $entityType => $attributes) {
+            try {
+                $entityTypeId = $this->eavConfig->getEntityType($entityType)->getEntityTypeId();
+            } catch (LocalizedException $e) {
+                continue;
+            }
+            $identities = array_merge(
+                $identities,
+                $this->getEavAttributeIds($entityTypeId, array_map(fn($item) => $item['attribute_code'], $attributes))
+            );
+        }
+        return $identities;
     }
 }

--- a/Model/GraphQlReader.php
+++ b/Model/GraphQlReader.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Graycore\CustomAttributeMetadataCache\Model;
+
+use Magento\Framework\Config\ReaderInterface;
+
+class GraphQlReader implements ReaderInterface
+{
+    public function read($scope = null)
+    {
+        return [
+            'Query' => [
+                'fields' => [
+                    'customAttributeMetadata' => [
+                        'cache' => [
+                            'cacheable' => true,
+                            'cacheIdentity' => CacheIdentity::class
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/Test/Unit/CacheIdentityTest.php
+++ b/Test/Unit/CacheIdentityTest.php
@@ -10,7 +10,12 @@ class CacheIdentityTest extends \PHPUnit\Framework\TestCase
 
     public function testItWorks(): void
     {
-        $identity = new CacheIdentity();
+        $om = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $identity = new CacheIdentity(
+            $om->getObject(\Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory::class),
+            $om->getObject(\Magento\Eav\Model\Config::class),
+
+        );
 
         $this->assertTrue($identity instanceof IdentityInterface);
     }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Magento\Framework\GraphQlSchemaStitching\Reader" type="Magento\Framework\GraphQlSchemaStitching\Common\Reader">
+        <arguments>
+            <argument name="readers" xsi:type="array">
+                <item name="custom_attribute_metadata_cache_graphql_reader" xsi:type="object">Graycore\CustomAttributeMetadataCache\Model\GraphQlReader</item>
+            </argument>
+        </arguments>
+    </virtualType>
+</config>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-custom-attribute-metadata-cache/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`customAttributeMetadata` is uncached.

Fixes: N/A


## What is the new behavior?
This adds the functionality of this package, it caches `customAttributeMetadata`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information

The graphql reader is just so that I don't have to copy stuff from core and then only add a cache identity. 

I chose this over modifying `schema.graphqls` so that it does not mess with other potential modifications to this query (maybe someone else adding a parameter or changing the return type of the query, etc)
