### PR TITLE
feat(eav, graphql): cache customAttributeMetadata

### DIFF
--- a/Model/CacheIdentity.php
+++ b/Model/CacheIdentity.php
@@ -1,13 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See https://github.com/mage-os/mageos-magento2/blob/2.4-develop/COPYING.txt for license details.
+ */
+
 namespace Graycore\CustomAttributeMetadataCache\Model;
 
+use Magento\Eav\Model\Entity\Attribute as EavAttribute;
 use Magento\Framework\GraphQl\Query\Resolver\IdentityInterface;
 
 class CacheIdentity implements IdentityInterface
 {
+    /**
+     * @inheritDoc
+     */
     public function getIdentities(array $resolvedData): array
     {
-        return [];
+        $identities = [];
+        if (isset($resolvedData['items']) && !empty($resolvedData['items'])) {
+            foreach ($resolvedData['items'] as $item) {
+                if (is_array($item)) {
+                    $identities[] = sprintf(
+                        "%s_%s_%s",
+                        EavAttribute::CACHE_TAG,
+                        $item['entity_type'],
+                        $item['attribute_code']
+                    );
+                }
+            }
+        } else {
+            return [];
+        }
+        return $identities;
     }
 }

--- a/Plugin/Eav/AttributePlugin.php
+++ b/Plugin/Eav/AttributePlugin.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See https://github.com/mage-os/mageos-magento2/blob/2.4-develop/COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Graycore\CustomAttributeMetadataCache\Plugin\Eav;
+
+use Magento\Eav\Model\Entity\Attribute;
+use Magento\Framework\Api\AttributeInterface;
+
+/**
+ * EAV plugin runs page cache clean and provides proper EAV identities.
+ */
+class AttributePlugin
+{
+    /**
+     * Clean cache by relevant tags after entity save.
+     *
+     * @param Attribute $subject
+     * @param array $result
+     *
+     * @return string[]
+     */
+    public function afterGetIdentities(Attribute $subject, array $result): array
+    {
+        return array_merge(
+            $result,
+            [
+                sprintf(
+                    "%s_%s_%s",
+                    Attribute::CACHE_TAG,
+                    $subject->getEntityType()->getEntityTypeCode(),
+                    $subject->getOrigData(AttributeInterface::ATTRIBUTE_CODE)
+                        ?? $subject->getData(AttributeInterface::ATTRIBUTE_CODE)
+                )
+            ]
+        );
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Eav\Model\Entity\Attribute">
+        <plugin name="entityAttributeChangePlugin" type="Graycore\CustomAttributeMetadataCache\Plugin\Eav\AttributePlugin" />
+    </type>
+</config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,6 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See https://github.com/mage-os/mageos-magento2/blob/2.4-develop/COPYING.txt for license details.
+
+type Query {
+        customAttributeMetadata(attributes: [AttributeInput!]! ): CustomAttributeMetadata @cache(cacheIdentity: "Graycore\\CustomAttributeMetadataCache\\Model\\CacheIdentity")
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-custom-attribute-metadata-cache/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Older versions of Magento don't have a cache for `customAttributeMetadata`. 

Fixes: N/A


## What is the new behavior?
In v2.4.7, Magento added a cache. This backports that cache code to a separate plugin.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information